### PR TITLE
machine-readable

### DIFF
--- a/iops
+++ b/iops
@@ -24,9 +24,11 @@
 # Benjamin Schweizer, http://benjamin-schweizer.de/contact
 # Uwe Menges
 # John Keith Hohm <john at hohm dot net>
+# Thorsten Staerk <dev at staerk dot de>
 #
 # Changes
 # ~~~~~~~
+# 2015-08-02, thorsten: machine-readable output by option to remove SI units
 # 2013-04-19, benjamin: support for non-root users
 # 2011-02-10, john: added win32 support
 # 2010-09-13, benjamin: increased num_threads default to 32 (max-ncq)
@@ -46,11 +48,12 @@ USAGE = """Copyright (c) 2008-2013 Benjamin Schweizer and others.
 
 usage:
 
-    iops [-n|--num_threads threads] [-t|--time time] <device>
+    iops [-n|--num_threads threads] [-t|--time time] [-m|--machine-readable] <device>
 
     threads := number of concurrent io threads, default 32
     time    := time in seconds, default 2
     device  := some block device, like /dev/sda or \\\\.\\PhysicalDrive0
+    machine-readable : used to switch off conversion into MiB and other SI units
 
 example:
 

--- a/iops
+++ b/iops
@@ -141,7 +141,9 @@ def greek(value, precision=0, prefix=None):
     """Return a string representing the IEC or SI suffix of a value"""
     # Copyright (c) 1999 Martin Pohl, copied from
     # http://mail.python.org/pipermail/python-list/1999-December/018519.html
-    if prefix:
+    if prefix=="machine-readable":
+        _abbrevs = [ (1     , ' ') ]
+    elif prefix=="si":
         # Use SI (10-based) units
         _abbrevs = [
             (10**15, 'P'),
@@ -203,6 +205,7 @@ if __name__ == '__main__':
     # parse cli
     t = 2
     num_threads = 32
+    units="si"
     dev = None
 
     if len(sys.argv) < 2:
@@ -214,13 +217,15 @@ if __name__ == '__main__':
             num_threads = int(sys.argv.pop(0))
         elif arg in ['-t', '--time']:
             t = int(sys.argv.pop(0))
+        elif arg in ['-m', '--machine-readable']:
+	    units = "machine-readable"
         else:
             dev = arg
 
     # run benchmark
     blocksize = 512
     try:
-        print "%s, %sB, %d threads:" % (dev, greek(mediasize(dev), 2, 'si'), num_threads)
+        print "%s, %sB, %d threads:" % (dev, greek(mediasize(dev), 2, units), num_threads)
         _iops = num_threads+1 # initial loop
         while _iops > num_threads and blocksize < mediasize(dev):
             # threading boilerplate
@@ -242,8 +247,8 @@ if __name__ == '__main__':
             _iops = sum(results)
 
             bandwidth = int(blocksize*_iops)
-            print " %sB blocks: %6.1f IO/s, %sB/s (%sbit/s)" % (greek(blocksize), _iops,
-                greek(bandwidth, 1), greek(8*bandwidth, 1, 'si'))
+            print " %sB blocks: %6.1f IO/s, %sB/s (%sbit/s)" % (greek(blocksize, 0, units), _iops,
+                greek(bandwidth, 1, units), greek(8*bandwidth, 1, units))
 
             blocksize *= 2
     except IOError, (err_no, err_str):


### PR DESCRIPTION
Wanted to create a gnuplot graph out of the results. A switch --machine-readable to avoid the SI units will make this more simple to every user.
