### PR TITLE
Correct spelling mistake

### DIFF
--- a/iops
+++ b/iops
@@ -38,7 +38,7 @@
 
 USAGE = """Copyright (c) 2008-2016 Benjamin Schweizer and others.
 
-iops is an IO benachmark tool that performs random reads on block devices.
+iops is an IO benchmark tool that performs random reads on block devices.
 If an exact block size is not specified using -b, the the size starts with
 the physical sector size (defaulting to 4k) and doubles every iteration of
 the loop. You can switch the read pattern using -p toggle.


### PR DESCRIPTION
Correct the spelling of benchmark. Nothing major.
