### PR TITLE
manual device size and sector size override

### DIFF
--- a/iops
+++ b/iops
@@ -233,6 +233,8 @@ if __name__ == '__main__':
     dev = None                  # /dev/sda
     exact_blocksize = False
     pattern='random'            # random|sequential
+    sectorsize=0
+    mediasize=0
 
     if len(sys.argv) < 2:
         raise SystemExit(USAGE)
@@ -248,6 +250,10 @@ if __name__ == '__main__':
         elif arg in ['-b', '--block-size']:
             blocksize = int(sys.argv.pop(0))
             exact_blocksize = True
+        elif arg in ['--override-sector-size']:
+	    sectorsize = int(sys.argv.pop(0))
+        elif arg in ['--override-media-size']:
+            mediasize = int(sys.argv.pop(0))
         elif arg in ['-p', '--pattern']:
             pattern = sys.argv.pop(0)
             if not pattern in ['random', 'sequential']:
@@ -257,7 +263,10 @@ if __name__ == '__main__':
 
     # run benchmark
     try:
-        mediasize, sectorsize = getsizes(dev)
+	if (not (sectorsize > 0 and mediasize > 0)):
+             mediasize, sectorsize = getsizes(dev)
+	else:
+	     print "sectorsize and mediasize override"
         print "%s, %s, sectorsize=%dB, #threads=%d, pattern=%s:" % (dev, greek(mediasize, 2, units), sectorsize, num_threads, pattern)
         _iops = num_threads+1 # initial loop
         while _iops > max(1, num_threads/4) and blocksize < mediasize:


### PR DESCRIPTION
I added this to deal with 2 situations:

- on some older Linux platforms fcntl.ioctl(fh.fileno(), BLKPBSZGET, buf, 1) and fcntl.ioctl(fh.fileno(), BLKGETSIZE64, buf, 1) fail with "invalid parameter" ... this override is a way to run iops even on such platforms.  
- sometimes for accurate benchmark it is important to artificially restrict device size.  Extreme example of this is this:  benchmark of 20 GB LUN on machine with 8 GB RAM gives much better performance than 2000 GB LUN on the same machine and same RAID (because of OS level caching).   To compare apples with apples, it's useful to artificially cap the 2000 GB LUN to be only 20 GB also.
