### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:2
+
+ADD ./iops /usr/src/iops/
+WORKDIR /usr/src/iops/
+
+ENTRYPOINT [ "./iops" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Python image, pinned to 2.x tag. More info at https://hub.docker.com/_/python/
No python install needed on systems with Docker, both for running on production or for developing/testing.

Just adding files, setting working dir and setting default entrypoint.

Build:

```
$ docker build -t iops .
```

Run:

```
$ docker run --rm -it iops [options]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it pataquets/iops [options...]
```
Using `--rm` causes the container to be deleted after stop.