### PR TITLE
Be explicit about python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,5 @@ $ iops --time 10 --num-threads 1 --block-size 16768 --pattern sequential /dev/di
 
 Links
 -----
-- http://www.linux-magazin.de/Ausgaben/2016/03/I-O-Benchmarking (German)
-- http://www.admin-magazine.com/Archive/2016/32/Fundamentals-of-I-O-benchmarking (English)
+- [Grundlagen des I/O-Benchmarking](https://www.linux-magazin.de/ausgaben/2016/03/i-o-benchmarking/) (German)
+- [Fundamentals of I/O benchmarking](https://www.admin-magazine.com/Archive/2016/32/Fundamentals-of-I-O-benchmarking) (English)

--- a/iops
+++ b/iops
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2008-2016 Benjamin Schweizer and others.
 #


### PR DESCRIPTION
Short of rewriting this for Python 3, be explicit to call `python2` as most installations have `python` point to `python3` nowadays. Also, add titles to the URLs in the `README` to prevent link rot.